### PR TITLE
Fix scripts for pushing Docker images. Finish script for generating bootstrap manifests.

### DIFF
--- a/clusterctl/examples/digitalocean/cluster.yaml.template
+++ b/clusterctl/examples/digitalocean/cluster.yaml.template
@@ -1,7 +1,7 @@
 apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Cluster
 metadata:
-  name: test1
+  name: $CLUSTER_NAME
 spec:
     clusterNetwork:
         services:

--- a/clusterctl/examples/digitalocean/generate-yaml.sh
+++ b/clusterctl/examples/digitalocean/generate-yaml.sh
@@ -1,10 +1,20 @@
 #!/bin/sh
 set -e
 
-PROVIDERCOMPONENT_TEMPLATE_FILE=provider-components.yaml.template
-PROVIDERCOMPONENT_GENERATED_FILE=provider-components.yaml
-
 OVERWRITE=0
+OUTPUT_DIR=out
+
+PROVIDERCOMPONENT_TEMPLATE_FILE=provider-components.yaml.template
+PROVIDERCOMPONENT_GENERATED_FILE=${OUTPUT_DIR}/provider-components.yaml
+MACHINES_TEMPLATE_FILE=machines.yaml.template
+MACHINES_GENERATED_FILE=${OUTPUT_DIR}/machines.yaml
+CLUSTER_TEMPLATE_FILE=cluster.yaml.template
+CLUSTER_GENERATED_FILE=${OUTPUT_DIR}/cluster.yaml
+
+REGION=fra1
+CLUSTER_NAME=test-1
+MASTER_NAME=digitalocean-fra1-master-1
+NODE_NAME=digitalocean-fra1-node-1
 
 SCRIPT=$(basename $0)
 while test $# -gt 0; do
@@ -38,17 +48,21 @@ if [ $OVERWRITE -ne 1 ] && [ -f $PROVIDERCOMPONENT_GENERATED_FILE ]; then
   exit 1
 fi
 
-OS=$(uname)
-if [[ "$OS" =~ "Linux" ]]; then
-elif [[ "$OS" =~ "Darwin" ]]; then
-else
-  echo "Unrecognized OS : $OS"
-  exit 1
-fi
+mkdir -p ${OUTPUT_DIR}
 
 cat $PROVIDERCOMPONENT_TEMPLATE_FILE \
   > $PROVIDERCOMPONENT_GENERATED_FILE
-
 echo "Done generating $PROVIDERCOMPONENT_GENERATED_FILE"
-echo "You will still need to generate the cluster.yaml and machines.yaml"
+
+cat $MACHINES_TEMPLATE_FILE \
+    | sed -e "s/\$REGION/$REGION/" \
+    | sed -e "s/\$MASTER_NAME/$MASTER_NAME/" \
+    | sed -e "s/\$NODE_NAME/$NODE_NAME/" \
+  > $MACHINES_GENERATED_FILE
+echo "Done generating $MACHINES_GENERATED_FILE"
+
+cat $CLUSTER_TEMPLATE_FILE \
+    | sed -e "s/\$CLUSTER_NAME/$CLUSTER_NAME/" \
+  > $CLUSTER_GENERATED_FILE
+echo "Done generating $CLUSTER_GENERATED_FILE"
 

--- a/clusterctl/examples/digitalocean/machines.yaml.template
+++ b/clusterctl/examples/digitalocean/machines.yaml.template
@@ -2,14 +2,45 @@ items:
 - apiVersion: "cluster.k8s.io/v1alpha1"
   kind: Machine
   metadata:
-    generateName: digitalocean-controlplane-
+    generateName: $MASTER_NAME
     labels:
-      set: controlplane
+      set: master
   spec:
+    providerConfig:
+      region: "$REGION"
+      size: "s-2vcpu-2gb"
+      image: "ubuntu-18-04-x64"
+      tags:
+        - "machine-1"
+       sshPublicKeys:
+        - "ssh-rsa AAAA"
+      private_networking: false
+      backups: false
+      ipv6: false
+      # must be disabled for coreos instances.
+      monitoring: true
+    versions:
+      controlPlane: 1.9.4
+      kubelet: 1.9.4
 - apiVersion: "cluster.k8s.io/v1alpha1"
   kind: Machine
   metadata:
-    generateName: digitalocean-node-
+    generateName: $NODE_NAME
     labels:
       set: node
   spec:
+    providerConfig:
+      region: "$REGION"
+      size: "s-2vcpu-2gb"
+      image: "ubuntu-18-04-x64"
+      tags:
+        - "machine-1"
+      sshPublicKeys:
+        - "ssh-rsa AAAA"
+      private_networking: false
+      backups: false
+      ipv6: false
+      # must be disabled for coreos instances.
+      monitoring: true
+    versions:
+      kubelet: 1.9.4

--- a/clusterctl/examples/digitalocean/provider-components.yaml.template
+++ b/clusterctl/examples/digitalocean/provider-components.yaml.template
@@ -45,7 +45,7 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: digitalocean-cluster-controller
-        image: gcr.io/k8s-cluster-api/digitalocean-cluster-controller:0.0.1
+        image: quay.io/kubermatic/digitalocean-cluster-controller:0.0.1
         volumeMounts:
           - name: config
             mountPath: /etc/kubernetes
@@ -69,7 +69,7 @@ spec:
             cpu: 400m
             memory: 500Mi
       - name: digitalocean-machine-controller
-        image: gcr.io/k8s-cluster-api/digitalocean-machine-controller:0.0.1
+        image: quay.io/kubermatic/digitalocean-machine-controller:0.0.1
         volumeMounts:
           - name: config
             mountPath: /etc/kubernetes

--- a/cmd/cluster-controller/Makefile
+++ b/cmd/cluster-controller/Makefile
@@ -14,9 +14,8 @@
 
 .PHONY: image
 
-GCR_BUCKET = k8s-cluster-api
-PREFIX = gcr.io/$(GCR_BUCKET)
-DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
+QUAY_BUCKET = kubermatic
+PREFIX = quay.io/$(QUAY_BUCKET)
 NAME = digitalocean-cluster-controller
 TAG = 0.0.1
 
@@ -25,14 +24,3 @@ image:
 
 push: image
 	docker push "$(PREFIX)/$(NAME):$(TAG)"
-	$(MAKE) fix_gcs_permissions
-
-fix_gcs_permissions:
-	gsutil acl ch -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
-	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
-
-dev_image:
-	docker build -t "$(DEV_PREFIX)/$(NAME):$(TAG)-dev" -f ./Dockerfile ../..
-
-dev_push: dev_image
-	docker push "$(DEV_PREFIX)/$(NAME):$(TAG)-dev"

--- a/cmd/machine-controller/Dockerfile
+++ b/cmd/machine-controller/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /go/src/github.com/kubermatic/cluster-api-provider-digitalocean
 # e.g. docker build -t <tag> -f <this_Dockerfile> <path_to_cluster-api-digitalocean>
 COPY . . 
 
-RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' github.com/kubermatic/cluster-api-provider-digitalocean/cmd/machine-digitalocean
+RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' github.com/kubermatic/cluster-api-provider-digitalocean/cmd/machine-controller
 
 # Final container
 FROM debian:stretch-slim

--- a/cmd/machine-controller/Makefile
+++ b/cmd/machine-controller/Makefile
@@ -14,9 +14,8 @@
 
 .PHONY: image
 
-GCR_BUCKET = k8s-cluster-api
-PREFIX = gcr.io/$(GCR_BUCKET)
-DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
+QUAY_BUCKET = kubermatic
+PREFIX = quay.io/$(QUAY_BUCKET)
 NAME = digitalocean-machine-controller
 TAG = 0.0.1
 
@@ -25,14 +24,4 @@ image:
 
 push: image
 	docker push "$(PREFIX)/$(NAME):$(TAG)"
-	$(MAKE) fix_gcs_permissions
 
-fix_gcs_permissions:
-	gsutil acl ch -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
-	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
-
-dev_image:
-	docker build -t "$(DEV_PREFIX)/$(NAME):$(TAG)-dev" -f ./Dockerfile ../..
-
-dev_push: dev_image
-	docker push "$(DEV_PREFIX)/$(NAME):$(TAG)-dev"


### PR DESCRIPTION
**What this PR does / why we need it**:

* Fixes Makefiles and Dockerfiles for `cluster-controller` and `machine-controller`. Targets not needed for quay.io are removed. The Makefile now uses our appropriate `quay.io` repositories instead of default `gcr.io`. Errors when building images are fixed.

* Finish script for generating bootstrap manifests. Earlier we just had a simple script for building `provider-config.yam`l. Now, the script is updated to handle `machines.yaml` and `cluster.yaml` manifests as well. Environment variables can be used along with the script to customize resulting manifests.

**Special notes for your reviewer**:

* Two new repositories are created in `quay.io/kubermatic` - `quay.io/kubermatic/digitalocean-cluster-controller` and `quay.io/kubermatic/digitalocean-machine-controller`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add scripts for generating bootstrap manifests.
```