### PR TITLE
ci: push to quay.io from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,24 @@ jobs:
         paths:
         - /go/src/github.com/kubermatic/cluster-api-provider-digitalocean
 
+  publish:
+    <<: *defaults
+    docker:
+    - image: docker:stable
+    steps:
+    - restore_cache:
+        key: repo-{{ .Environment.CIRCLE_SHA1 }}
+    - restore_cache:
+        key: cluster-api-provider-digitalocean-{{ .Revision }}
+    - setup_remote_docker
+    - run: apk update && apk add make bash git
+    - run: |
+        set -e
+        export GIT_TAG=$CIRCLE_TAG
+        docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
+        make images-nodep
+        make push-nodep
+
 workflows:
   version: 2
   build:
@@ -82,3 +100,15 @@ workflows:
         filters:
           tags:
             only: /v.*/
+    - publish:
+        requires:
+        - build
+        - test
+        - check-dependencies
+        filters:
+          branches:
+            only:
+            - master
+          tags:
+            only: /v.*/
+

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,15 @@ images: depend
 	$(MAKE) -C cmd/cluster-controller image
 	$(MAKE) -C cmd/machine-controller image
 
+images-nodep:
+	$(MAKE) -C cmd/cluster-controller image
+	$(MAKE) -C cmd/machine-controller image
+
 push: depend
+	$(MAKE) -C cmd/cluster-controller push
+	$(MAKE) -C cmd/machine-controller push
+
+push-nodep:
 	$(MAKE) -C cmd/cluster-controller push
 	$(MAKE) -C cmd/machine-controller push
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* Push `digitalocean-cluster-controller` and `digitalocean-machine-controller` images from CI.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```