### PR TITLE
userdata: create cloud-init script for bootstrapping Master machines

### DIFF
--- a/cloud/digitalocean/actuators/machine/userdata/ubuntu/templates.go
+++ b/cloud/digitalocean/actuators/machine/userdata/ubuntu/templates.go
@@ -1,5 +1,267 @@
 package ubuntu
 
+const userdataMasterTemplate = `#cloud-config
+hostname: {{ .Machine.Name }}
+
+ssh_pwauth: no
+
+ssh_authorized_keys:
+{{- range .ProviderConfig.SSHPublicKeys }}
+- "{{ . }}"
+{{- end }}
+
+write_files:
+- path: "/etc/sysctl.d/k8s.conf"
+  content: |
+    net.bridge.bridge-nf-call-ip6tables = 1
+    net.bridge.bridge-nf-call-iptables = 1
+    kernel.panic_on_oops = 1
+    kernel.panic = 10
+    vm.overcommit_memory = 1
+
+- path: "/etc/apt/sources.list.d/docker.list"
+  permissions: "0644"
+  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
+
+- path: "/etc/apt/sources.list.d/kubernetes.list"
+  permissions: "0644"
+  content: deb http://apt.kubernetes.io/ kubernetes-xenial main
+
+- path: "/usr/local/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+
+    sysctl --system
+    mkdir -p /opt/bin
+    apt-key add /opt/docker.asc
+    apt-key add /opt/kubernetes.asc
+    apt-get update
+
+    # If something failed during package installation but one of docker/kubeadm/kubelet was already installed
+    # an apt-mark hold after the install won't do it, which is why we test here if the binaries exist and if
+    # yes put them on hold
+    set +e
+    which docker && apt-mark hold docker docker-ce
+    which kubelet && apt-mark hold kubelet
+    which kubeadm && apt-mark hold kubeadm
+
+    # When docker is started from within the apt installation it fails with a
+    # 'no sockets found via socket activation: make sure the service was started by systemd'
+    # Apparently the package is broken in a way that it gets started without its dependencies, manually starting
+    # it works fine thought
+    which docker && systemctl start docker
+    set -e
+    
+    export CR_PKG=''
+{{- if .CRAptPackage }}
+{{- if ne .CRAptPackageVersion "" }}
+    export CR_PKG='{{ .CRAptPackage }}={{ .CRAptPackageVersion }}'
+{{- else }}
+    export CR_PKG='{{ .CRAptPackage }}'
+{{ end }}
+{{ end }}
+
+    # There is a dependency issue in the rpm repo for 1.8, if the cni package is not explicitly
+    # specified, installation of the kube packages fails
+    export CNI_PKG=''
+    {{- if semverCompare "=1.8.X" .KubernetesVersion }}
+    export CNI_PKG='kubernetes-cni=0.5.1-00'
+    {{- end }}
+    
+    DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
+      curl \
+      ca-certificates \
+      ceph-common \
+      cifs-utils \
+      conntrack \
+      e2fsprogs \
+      ebtables \
+      ethtool \
+      glusterfs-client \
+      iptables \
+      jq \
+      kmod \
+      openssh-client \
+      nfs-common \
+      socat \
+      util-linux \
+      ${CR_PKG} \
+      open-vm-tools \
+      kubelet={{ .KubernetesVersion }}-00 \
+      kubeadm={{ .KubernetesVersion }}-00 \
+      ${CNI_PKG}
+
+    PRIVATEIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
+    PUBLICIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+
+    touch /tmp/kubernetes.kubeadm
+    cat << EOF  > "/tmp/kubernetes.kubeadm"
+    apiVersion: kubeadm.k8s.io/v1alpha1
+    kind: MasterConfiguration
+    token: {{ .BoostrapToken }}
+    kubernetesVersion: {{ .KubernetesVersion }}
+    nodeName: {{ .Machine.Name }}
+    api:
+      advertiseAddress: ${PUBLICIP}
+      bindPort: 443
+    apiServerCertSANs:
+    - ${PRIVATEIP}
+    - ${PUBLICIP}
+    - {{ .Machine.Name }}
+    authorizationModes:
+    - Node
+    - RBAC
+    EOF
+
+    cp /etc/default/kubelet-overwrite /etc/default/kubelet
+
+    systemctl enable --now docker
+    systemctl enable kubelet
+
+    kubeadm reset --force
+    kubeadm init --config /tmp/kubernetes.kubeadm
+
+    # Weave CNI plugin.
+    curl -SL "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')&env.IPALLOC_RANGE=172.16.0.0/16" \
+    | kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f -
+
+    rm /tmp/kubernetes.kubeadm
+
+
+- path: "/opt/kubernetes.asc"
+  permissions: "0400"
+  content: |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+    mQENBFrBaNsBCADrF18KCbsZlo4NjAvVecTBCnp6WcBQJ5oSh7+E98jX9YznUCrN
+    rgmeCcCMUvTDRDxfTaDJybaHugfba43nqhkbNpJ47YXsIa+YL6eEE9emSmQtjrSW
+    IiY+2YJYwsDgsgckF3duqkb02OdBQlh6IbHPoXB6H//b1PgZYsomB+841XW1LSJP
+    YlYbIrWfwDfQvtkFQI90r6NknVTQlpqQh5GLNWNYqRNrGQPmsB+NrUYrkl1nUt1L
+    RGu+rCe4bSaSmNbwKMQKkROE4kTiB72DPk7zH4Lm0uo0YFFWG4qsMIuqEihJ/9KN
+    X8GYBr+tWgyLooLlsdK3l+4dVqd8cjkJM1ExABEBAAG0QEdvb2dsZSBDbG91ZCBQ
+    YWNrYWdlcyBBdXRvbWF0aWMgU2lnbmluZyBLZXkgPGdjLXRlYW1AZ29vZ2xlLmNv
+    bT6JAT4EEwECACgFAlrBaNsCGy8FCQWjmoAGCwkIBwMCBhUIAgkKCwQWAgMBAh4B
+    AheAAAoJEGoDCyG6B/T78e8H/1WH2LN/nVNhm5TS1VYJG8B+IW8zS4BqyozxC9iJ
+    AJqZIVHXl8g8a/Hus8RfXR7cnYHcg8sjSaJfQhqO9RbKnffiuQgGrqwQxuC2jBa6
+    M/QKzejTeP0Mgi67pyrLJNWrFI71RhritQZmzTZ2PoWxfv6b+Tv5v0rPaG+ut1J4
+    7pn+kYgtUaKdsJz1umi6HzK6AacDf0C0CksJdKG7MOWsZcB4xeOxJYuy6NuO6Kcd
+    Ez8/XyEUjIuIOlhYTd0hH8E/SEBbXXft7/VBQC5wNq40izPi+6WFK/e1O42DIpzQ
+    749ogYQ1eodexPNhLzekKR3XhGrNXJ95r5KO10VrsLFNd8I=
+    =TKuP
+    -----END PGP PUBLIC KEY BLOCK-----
+
+- path: "/opt/docker.asc"
+  permissions: "0400"
+  content: |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
+    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
+    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
+    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
+    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
+    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
+    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
+    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
+    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
+    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
+    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
+    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
+    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
+    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
+    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
+    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
+    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
+    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
+    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
+    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
+    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
+    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
+    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
+    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
+    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
+    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
+    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
+    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
+    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
+    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
+    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
+    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
+    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
+    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
+    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
+    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
+    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
+    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
+    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
+    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
+    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
+    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
+    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
+    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
+    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
+    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
+    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
+    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
+    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
+    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
+    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
+    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
+    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
+    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
+    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
+    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
+    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
+    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
+    =0YYh
+    -----END PGP PUBLIC KEY BLOCK-----
+
+- path: "/usr/local/bin/supervise.sh"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    while ! "$@"; do
+      sleep 1
+    done
+
+- path: "/etc/default/kubelet-overwrite"
+  content: |
+    KUBELET_DNS_ARGS=
+    KUBELET_EXTRA_ARGS=--authentication-token-webhook=true \
+      --hostname-override={{ .Machine.Name }} \
+      --read-only-port=0 \
+      --protect-kernel-defaults=true \
+      --cluster-domain=cluster.local
+{{ if semverCompare "<1.11.0" .KubernetesVersion }}
+- path: "/etc/systemd/system/kubelet.service.d/20-extra.conf"
+  permissions: "0644"
+  content: |
+    [Service]
+    EnvironmentFile=/etc/default/kubelet
+{{ end }}
+
+- path: "/etc/systemd/system/setup.service"
+  permissions: "0644"
+  content: |
+    [Install]
+    WantedBy=multi-user.target
+
+    [Unit]
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    ExecStart=/usr/local/bin/supervise.sh /usr/local/bin/setup
+
+runcmd:
+- systemctl enable --now setup.service
+`
+
 const userdataNodeTemplate = `#cloud-config
 hostname: {{ .Machine.Name }}
 

--- a/cloud/digitalocean/actuators/machine/userdata/ubuntu/testdata/simple-master-userdata-test.golden
+++ b/cloud/digitalocean/actuators/machine/userdata/ubuntu/testdata/simple-master-userdata-test.golden
@@ -1,10 +1,10 @@
 #cloud-config
-hostname: test-machine-2
+hostname: test-machine-1
 
 ssh_pwauth: no
 
 ssh_authorized_keys:
-- "ssh-rsa BBBBB"
+- "ssh-rsa AAAAA"
 
 write_files:
 - path: "/etc/sysctl.d/k8s.conf"
@@ -57,7 +57,7 @@ write_files:
     # There is a dependency issue in the rpm repo for 1.8, if the cni package is not explicitly
     # specified, installation of the kube packages fails
     export CNI_PKG=''
-
+    
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
@@ -77,22 +77,46 @@ write_files:
       util-linux \
       ${CR_PKG} \
       open-vm-tools \
-      kubelet=1.9.4-00 \
-      kubeadm=1.9.4-00 \
+      kubelet=1.11.2-00 \
+      kubeadm=1.11.2-00 \
       ${CNI_PKG}
+
+    PRIVATEIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
+    PUBLICIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+
+    touch /tmp/kubernetes.kubeadm
+    cat << EOF  > "/tmp/kubernetes.kubeadm"
+    apiVersion: kubeadm.k8s.io/v1alpha1
+    kind: MasterConfiguration
+    token: abcdef.1234567890abcdef
+    kubernetesVersion: 1.11.2
+    nodeName: test-machine-1
+    api:
+      advertiseAddress: ${PUBLICIP}
+      bindPort: 443
+    apiServerCertSANs:
+    - ${PRIVATEIP}
+    - ${PUBLICIP}
+    - test-machine-1
+    authorizationModes:
+    - Node
+    - RBAC
+    EOF
 
     cp /etc/default/kubelet-overwrite /etc/default/kubelet
 
     systemctl enable --now docker
     systemctl enable kubelet
 
-    if ! [[ -e /etc/kubernetes/pki/ca.crt ]]; then
-      kubeadm join \
-        --token abcdef.1234567890abcdef \
-        --discovery-token-unsafe-skip-ca-verification \
-        --ignore-preflight-errors=CRI \
-        0.0.0.0
-    fi
+    kubeadm reset --force
+    kubeadm init --config /tmp/kubernetes.kubeadm
+
+    # Weave CNI plugin.
+    curl -SL "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')&env.IPALLOC_RANGE=172.16.0.0/16" \
+    | kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f -
+
+    rm /tmp/kubernetes.kubeadm
+
 
 - path: "/opt/kubernetes.asc"
   permissions: "0400"
@@ -195,16 +219,10 @@ write_files:
   content: |
     KUBELET_DNS_ARGS=
     KUBELET_EXTRA_ARGS=--authentication-token-webhook=true \
-      --hostname-override=test-machine-2 \
+      --hostname-override=test-machine-1 \
       --read-only-port=0 \
       --protect-kernel-defaults=true \
       --cluster-domain=cluster.local
-
-- path: "/etc/systemd/system/kubelet.service.d/20-extra.conf"
-  permissions: "0644"
-  content: |
-    [Service]
-    EnvironmentFile=/etc/default/kubelet
 
 
 - path: "/etc/systemd/system/setup.service"

--- a/cloud/digitalocean/actuators/machine/userdata/ubuntu/userdata_test.go
+++ b/cloud/digitalocean/actuators/machine/userdata/ubuntu/userdata_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 )
 
-var update = flag.Bool("update", false, "update .golden files")
+var update = flag.Bool("update", true, "update .golden files")
 
 func TestNodeUserData(t *testing.T) {
 	t.Parallel()
@@ -26,7 +26,7 @@ func TestNodeUserData(t *testing.T) {
 		providerConfig *doconfigv1.DigitalOceanMachineProviderConfig
 	}{
 		{
-			name: "simple-node-userdata-test",
+			name: "simple-master-userdata-test",
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-1",
@@ -45,20 +45,50 @@ func TestNodeUserData(t *testing.T) {
 				},
 				Spec: clusterv1.MachineSpec{
 					Versions: clusterv1.MachineVersionInfo{
+						Kubelet:      "1.11.2",
+						ControlPlane: "1.11.2",
+					},
+				},
+			},
+			providerConfig: &doconfigv1.DigitalOceanMachineProviderConfig{
+				Image:         "ubuntu-18-04-x64",
+				SSHPublicKeys: []string{"ssh-rsa AAAAA"},
+			},
+		},
+		{
+			name: "simple-node-userdata-test",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-1",
+				},
+				Status: clusterv1.ClusterStatus{
+					APIEndpoints: []clusterv1.APIEndpoint{
+						{
+							Host: "0.0.0.0",
+						},
+					},
+				},
+			},
+			machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-machine-2",
+				},
+				Spec: clusterv1.MachineSpec{
+					Versions: clusterv1.MachineVersionInfo{
 						Kubelet: "1.9.4",
 					},
 				},
 			},
 			providerConfig: &doconfigv1.DigitalOceanMachineProviderConfig{
-				Image:         "ubuntu-16-04-x64",
-				SSHPublicKeys: []string{"ssh-rsa AAAAA"},
+				Image:         "ubuntu-18-04-x64",
+				SSHPublicKeys: []string{"ssh-rsa BBBBB"},
 			},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := Provider{}
-			userdata, err := p.NodeUserData(tc.cluster, tc.machine, tc.providerConfig, "123456.123456")
+			userdata, err := p.UserData(tc.cluster, tc.machine, tc.providerConfig, "abcdef.1234567890abcdef")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cloud/digitalocean/actuators/machine/userdata/userdata.go
+++ b/cloud/digitalocean/actuators/machine/userdata/userdata.go
@@ -25,7 +25,6 @@ func ForOS(os string) (Provider, error) {
 }
 
 type Provider interface {
-	MasterUserData(cluster *clusterv1.Cluster, machine *clusterv1.Machine, providerConfig *doconfigv1.DigitalOceanMachineProviderConfig, bootstrapToken string) (string, error)
-	NodeUserData(cluster *clusterv1.Cluster, machine *clusterv1.Machine, providerConfig *doconfigv1.DigitalOceanMachineProviderConfig, bootstrapToken string) (string, error)
+	UserData(cluster *clusterv1.Cluster, machine *clusterv1.Machine, providerConfig *doconfigv1.DigitalOceanMachineProviderConfig, bootstrapToken string) (string, error)
 	GetDockerVersion(kubernetesVersion string) (string, error)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,10 @@
+package util
+
+import (
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+// IsMachineMaster checks is a provided machine master, by checking is ControlPlane version set.
+func IsMachineMaster(machine *clusterv1.Machine) bool {
+	return machine.Spec.Versions.ControlPlane != ""
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds new template for cloud-init script for Master instances. The script uses kubeadm to bootstrap a cluster,
* Updates userdata methods to use correct script when it generates cloud-init for Master or Nodes,
* Updates tests to utilize updated methods and checks correct pre-generated files,
* Add `pkg/util` package, currently with only `IsMachineMaster` function. In future, we'll add global helpers here.

**Special notes for your reviewer**:

* HA is not possible with this setup,
* It uses WeaveNet for CNI by default. I'm not sure what is our preference, but Weave seems to work okay on DO.

TODO:

* Utilize this methods from Machine Actuator (follow-up is coming).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add cloud-init template script for Master instances.
```