### PR TITLE
cloud/digitalocean: wire machine actuator and userdata methods

### DIFF
--- a/cloud/digitalocean/actuators/machine/userdata/ubuntu/userdata.go
+++ b/cloud/digitalocean/actuators/machine/userdata/ubuntu/userdata.go
@@ -109,7 +109,9 @@ func (p Provider) UserData(cluster *clusterv1.Cluster, machine *clusterv1.Machin
 		CRAptPackageVersion:   crPkgVersion,
 		KubernetesVersion:     kubeletVersion.String(),
 		KubeadmDropInFilename: kubeadmDropInFilename,
-		ServerAddr:            cluster.Status.APIEndpoints[0].Host,
+	}
+	if len(cluster.Status.APIEndpoints) != 0 {
+		data.ServerAddr = cluster.Status.APIEndpoints[0].Host
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)

--- a/cloud/digitalocean/actuators/machine/userdata/userdata.go
+++ b/cloud/digitalocean/actuators/machine/userdata/userdata.go
@@ -14,6 +14,7 @@ var (
 
 	providers = map[string]Provider{
 		"ubuntu-16-04-x64": ubuntu.Provider{},
+		"ubuntu-18-04-x64": ubuntu.Provider{},
 	}
 )
 

--- a/clusterctl/examples/digitalocean/provider-components.yaml.template
+++ b/clusterctl/examples/digitalocean/provider-components.yaml.template
@@ -75,6 +75,8 @@ spec:
             mountPath: /etc/kubernetes
           - name: certs
             mountPath: /etc/ssl/certs
+          - name: kubeadm
+            mountPath: /usr/bin/kubeadm
         env:
         - name: DIGITALOCEAN_ACCESS_TOKEN
           valueFrom:
@@ -104,3 +106,6 @@ spec:
       - name: certs
         hostPath:
           path: /etc/ssl/certs
+      - name: kubeadm
+        hostPath:
+          path: /usr/bin/kubeadm


### PR DESCRIPTION
**What this PR does / why we need it**:

* Make Machine Actuator use new userdata methods to generate the cloud-init scripts for both master and nodes,
* Correctly handle Droplet tags,
* Mount kubeadm binary to the `machine-controller` container,
* Fix clusterctl panic when first master is bootstrapping.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```