### PR TITLE
ci: publish docker images only on tag changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,7 @@ workflows:
         - check-dependencies
         filters:
           branches:
-            only:
-            - master
+            ignore: /.*/
           tags:
             only: /v.*/
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we're trying to push new Docker image on every push to master. This PR reduces this, so we push only when there is a tag change. This allows better control over when we push images.

**Special notes for your reviewer**:

We need a robot account for this to work.

**Release note**:
```release-note
NONE
```