### PR TITLE
cloud/digitalocean: fix instance exists check in the update method

### DIFF
--- a/cloud/digitalocean/actuators/machine/actuator.go
+++ b/cloud/digitalocean/actuators/machine/actuator.go
@@ -249,7 +249,7 @@ func (do *DOClient) Update(cluster *clusterv1.Cluster, machine *clusterv1.Machin
 	if err != nil {
 		return err
 	}
-	if droplet != nil {
+	if droplet == nil {
 		return fmt.Errorf("machine %s doesn't exist", machine.Name)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix instance exists check in the update method.

**Release note**:
```release-note
NONE
```