### PR TITLE
cloud/digitalocean: implement getkubeconfig method

### DIFF
--- a/pkg/scp/scp.go
+++ b/pkg/scp/scp.go
@@ -43,7 +43,7 @@ func (cl *Client) ReadBytes(remotePath string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() {
-		if err := c.Close(); err != nil {
+		if err := r.Close(); err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to close ssh connection: %v", err))
 		}
 	}()
@@ -77,7 +77,7 @@ func (cl *Client) WriteBytes(remotePath string, content []byte) error {
 		return err
 	}
 	defer func() {
-		if err := c.Close(); err != nil {
+		if err := f.Close(); err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to close ssh connection: %v", err))
 		}
 	}()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements the `GetKubeConfig` method, used by the Machine Actuator to fetch the `kubeconfig` from master, once it's provisioned.

**Special notes for your reviewer**:

A follow-up for manifests update will be created.

**Release note**:
```release-note
Implement GetKubeConfig method for the machine actuator.
```