### PR TITLE
clusterctl: generate ssh key for machine controller in generator script

### DIFF
--- a/clusterctl/examples/digitalocean/generate-yaml.sh
+++ b/clusterctl/examples/digitalocean/generate-yaml.sh
@@ -17,6 +17,8 @@ MASTER_NAME=digitalocean-fra1-master-
 NODE_NAME=digitalocean-fra1-node-
 DIGITALOCEAN_ACCESS_TOKEN=${DIGITALOCEAN_ACCESS_TOKEN}
 
+SSH_KEY_GENERATED_FILE=${OUTPUT_DIR}/${CLUSTER_NAME}_rsa
+
 SCRIPT=$(basename $0)
 while test $# -gt 0; do
         case "$1" in
@@ -49,10 +51,36 @@ if [ $OVERWRITE -ne 1 ] && [ -f $PROVIDERCOMPONENT_GENERATED_FILE ]; then
   exit 1
 fi
 
+if [ $OVERWRITE -ne 1 ] && [ -f $MACHINES_GENERATED_FILE ]; then
+  echo "File $MACHINES_GENERATED_FILE already exists. Delete it manually before running this script."
+  exit 1
+fi
+
+if [ $OVERWRITE -ne 1 ] && [ -f $CLUSTER_GENERATED_FILE ]; then
+  echo "File $CLUSTER_GENERATED_FILE already exists. Delete it manually before running this script."
+  exit 1
+fi
+
+if [ $OVERWRITE -ne 1 ] && [ -f $SSH_KEY_GENERATED_FILE ]; then
+  echo "File $SSH_KEY_GENERATED_FILE already exists. Delete it manually before running this script."
+  exit 1
+fi
+
 mkdir -p ${OUTPUT_DIR}
+
+# This command generates new SSH key to be used by the machine controller to communicate with the cluster.
+# The SSH private/public keypair is saved in `out` directory, so it can be used by the user if needed.
+# The key doesn't have passphrase as locked SSH keys are not supported by the upstream API: https://github.com/kubernetes-sigs/cluster-api/issues/160
+ssh-keygen -f $SSH_KEY_GENERATED_FILE -N "" -C $CLUSTER_NAME -t rsa
+echo "Done generating SSH key $SSH_KEY_GENERATED_FILE"
+
+SSH_PUBLIC_KEY="$(cat ${SSH_KEY_GENERATED_FILE}.pub | base64 | tr -d '\r\n')"
+SSH_PRIVATE_KEY=$(cat ${SSH_KEY_GENERATED_FILE} | base64 | tr -d '\r\n')
 
 cat $PROVIDERCOMPONENT_TEMPLATE_FILE \
   | sed -e "s/\$DIGITALOCEAN_ACCESS_TOKEN/$DIGITALOCEAN_ACCESS_TOKEN/" \
+  | sed -e "s/\$SSH_PRIVATE_KEY/$SSH_PRIVATE_KEY/" \
+  | sed -e "s/\$SSH_PUBLIC_KEY/$SSH_PUBLIC_KEY/" \
   > $PROVIDERCOMPONENT_GENERATED_FILE
 echo "Done generating $PROVIDERCOMPONENT_GENERATED_FILE"
 

--- a/clusterctl/examples/digitalocean/provider-components.yaml.template
+++ b/clusterctl/examples/digitalocean/provider-components.yaml.template
@@ -79,6 +79,8 @@ spec:
             mountPath: /usr/bin/kubeadm
           - name: machine-config
             mountPath: /etc/machineconfig
+          - name: machine-controller-sshkeys
+            mountPath: /etc/sshkeys
         env:
         - name: DIGITALOCEAN_ACCESS_TOKEN
           valueFrom:
@@ -115,6 +117,10 @@ spec:
       - name: machine-config
         configMap:
           name: machine-config
+      - name: machine-controller-sshkeys
+        secret:
+          secretName: machine-controller-sshkeys
+          defaultMode: 256
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -265,3 +271,13 @@ metadata:
 type: Opaque
 stringData:
   token: $DIGITALOCEAN_ACCESS_TOKEN
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: machine-controller-sshkeys
+  namespace: default
+data:
+  private: $SSH_PRIVATE_KEY
+  public: $SSH_PUBLIC_KEY


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow-up of #23.

This PR updates the manifests generator script to generate SSH key to be used by the machine controller to bootstrap the cluster.

**Release note**:
```release-note
Update manifests generator scripts to generate SSH key for machine controller.
```