### PR TITLE
cloud/digitalocean: add environment variables template for master bootstrap script

### DIFF
--- a/cloud/digitalocean/actuators/machine/userdata.go
+++ b/cloud/digitalocean/actuators/machine/userdata.go
@@ -1,0 +1,65 @@
+package machine
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+// userdataParams are parameters used to parse the environment variables for bootstrap scripts.
+type userdataParams struct {
+	Machine     *clusterv1.Machine
+	Cluster     *clusterv1.Cluster
+	Token       string
+	PodCIDR     string
+	ServiceCIDR string
+}
+
+// masterUserdata builds master bootstrap script based on script provider in providerConfig and based on environment template.
+func masterUserdata(cluster *clusterv1.Cluster, machine *clusterv1.Machine, token, metadata string) (string, error) {
+	params := userdataParams{
+		Cluster:     cluster,
+		Machine:     machine,
+		Token:       token,
+		PodCIDR:     subnet(cluster.Spec.ClusterNetwork.Pods),
+		ServiceCIDR: subnet(cluster.Spec.ClusterNetwork.Services),
+	}
+	tmpl := template.Must(template.New("masterEnvironment").Parse(masterEnvironmentVariables))
+
+	b := &bytes.Buffer{}
+	err := tmpl.Execute(b, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute user-data template: %v", err)
+	}
+	b.Write([]byte(metadata))
+
+	return b.String(), nil
+}
+
+// subnet gets first IP of the subnet.
+func subnet(netRange clusterv1.NetworkRanges) string {
+	if len(netRange.CIDRBlocks) == 0 {
+		return ""
+	}
+	return netRange.CIDRBlocks[0]
+}
+
+const (
+	// masterEnvironment is the environment variables template for master instances.
+	masterEnvironmentVariables = `#!/bin/bash
+KUBELET_VERSION={{ .Machine.Spec.Versions.Kubelet }}
+VERSION=$KUBELET_VERSION
+TOKEN={{ .Token }}
+PORT=443
+NAMESPACE={{ .Machine.ObjectMeta.Namespace }}
+MACHINE=$NAMESPACE
+MACHINE+="/"
+MACHINE+={{ .Machine.ObjectMeta.Name }}
+CONTROL_PLANE_VERSION={{ .Machine.Spec.Versions.ControlPlane }}
+CLUSTER_DNS_DOMAIN={{ .Cluster.Spec.ClusterNetwork.ServiceDomain }}
+POD_CIDR={{ .PodCIDR }}
+SERVICE_CIDR={{ .ServiceCIDR }}
+`
+)

--- a/clusterctl/examples/digitalocean/provider-components.yaml.template
+++ b/clusterctl/examples/digitalocean/provider-components.yaml.template
@@ -145,16 +145,6 @@ data:
         PRIVATEIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
         PUBLICIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
 
-        # TODO: temp. Remove this!
-        export KUBELET_VERSION=1.9.4
-        export TOKEN="abcdef.1234567890abcdef"
-        export VERSION=1.9.4
-        export PORT=443
-        export MACHINE="default/"
-        export MACHINE+=$HOSTNAME
-        export CONTROL_PLANE_VERSION=1.9.4
-        export CLUSTER_DNS_DOMAIN=cluster.local
-
         curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
         touch /etc/apt/sources.list.d/kubernetes.list
         sh -c 'echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds functions for parsing bootstrap scripts for master instances.
The new parser function appends dynamically generated environment variables (generated from template) to the bootstrap script from providerConfig.

That way, we don't need templating in providerConfig bootstrap script, and users have variables that they can use in their bootstrap scripts as well.

**Special notes for your reviewer**:

TODO in a follow-up:
* Document available environment variables.

**Release note**:
```release-note
Generate from template and append needed environment variables to the master bootstrap script.
```