### PR TITLE
cloud/digitalocean: use correct providerConfig field for private_networking

### DIFF
--- a/cloud/digitalocean/actuators/machine/actuator.go
+++ b/cloud/digitalocean/actuators/machine/actuator.go
@@ -220,7 +220,7 @@ func (do *DOClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machin
 		},
 		Backups:           machineConfig.Backups,
 		IPv6:              machineConfig.IPv6,
-		PrivateNetworking: machineConfig.IPv6,
+		PrivateNetworking: machineConfig.PrivateNetworking,
 		Monitoring:        machineConfig.Monitoring,
 		Tags: append([]string{
 			string(machine.UID),


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes typo in DropletCreateRequest.

**Release note**:
```release-note
NONE
```