### PR TITLE
cloud/digitalocean: port instancestatus feature

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1117,6 +1117,7 @@
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/runtime/serializer/json",
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/uuid",
@@ -1140,6 +1141,7 @@
     "sigs.k8s.io/cluster-api/pkg/controller/machine",
     "sigs.k8s.io/cluster-api/pkg/controller/sharedinformers",
     "sigs.k8s.io/cluster-api/pkg/kubeadm",
+    "sigs.k8s.io/cluster-api/pkg/util",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cloud/digitalocean/actuators/machine/actuator.go
+++ b/cloud/digitalocean/actuators/machine/actuator.go
@@ -267,6 +267,10 @@ func (do *DOClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machin
 	if err != nil {
 		return err
 	}
+	err = do.updateInstanceStatus(machine)
+	if err != nil {
+		return err
+	}
 
 	do.eventRecorder.Eventf(machine, corev1.EventTypeNormal, eventReasonCreate, "machine %s successfully created", machine.ObjectMeta.Name)
 	return nil

--- a/cloud/digitalocean/actuators/machine/instancestatus.go
+++ b/cloud/digitalocean/actuators/machine/instancestatus.go
@@ -1,0 +1,105 @@
+package machine
+
+import (
+	"bytes"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/cluster-api/pkg/util"
+)
+
+// InstanceStatusAnnotationKey is the key of annotation which will hold the status of a machine.
+// In long term, we should find a better way to handle this.
+const InstanceStatusAnnotationKey = "instance-status"
+
+// instanceStatus is used for conversion between status in annotation and real machine object.
+type instanceStatus *clusterv1.Machine
+
+// instanceStatus returns machine object based on instance status from annotation.
+func (do *DOClient) instanceStatus(machine *clusterv1.Machine) (instanceStatus, error) {
+	if do.v1Alpha1Client == nil {
+		return nil, nil
+	}
+	currentMachine, err := util.GetMachineIfExists(do.v1Alpha1Client.Machines(machine.Namespace), machine.ObjectMeta.Name)
+	if err != nil {
+		return nil, err
+	}
+	if currentMachine == nil {
+		return nil, nil
+	}
+	return do.machineInstanceStatus(machine)
+}
+
+// machineInstanceStatus converts string from annotation to the machine object.
+func (do *DOClient) machineInstanceStatus(machine *clusterv1.Machine) (instanceStatus, error) {
+	if machine.ObjectMeta.Annotations == nil {
+		return nil, nil
+	}
+
+	a := machine.ObjectMeta.Annotations[InstanceStatusAnnotationKey]
+	if a == "" {
+		return nil, nil
+	}
+
+	var status clusterv1.Machine
+	serializer := json.NewSerializer(json.DefaultMetaFactory, do.scheme, do.scheme, false)
+	_, _, err := serializer.Decode([]byte(a), &schema.GroupVersionKind{
+		Group:   "",
+		Version: "cluster.k8s.io/v1alpha1",
+		Kind:    "Machine",
+	}, &status)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding machine status: %v", err)
+	}
+
+	return instanceStatus(&status), nil
+}
+
+// setMachineInstanceStatus writes the instance status to the annotation.
+func (do *DOClient) setMachineInstanceStatus(machine *clusterv1.Machine, status instanceStatus) (instanceStatus, error) {
+	// Avoid status within status.
+	status.ObjectMeta.Annotations[InstanceStatusAnnotationKey] = ""
+
+	b := []byte{}
+	buff := bytes.NewBuffer(b)
+	serializer := json.NewSerializer(json.DefaultMetaFactory, do.scheme, do.scheme, false)
+
+	err := serializer.Encode((*clusterv1.Machine)(status), buff)
+	if err != nil {
+		return nil, err
+	}
+
+	if machine.ObjectMeta.Annotations == nil {
+		machine.ObjectMeta.Annotations = make(map[string]string)
+	}
+	machine.ObjectMeta.Annotations[InstanceStatusAnnotationKey] = buff.String()
+
+	return machine, nil
+}
+
+// updateInstanceStatus updates the machine object with the new annotation.
+func (do *DOClient) updateInstanceStatus(machine *clusterv1.Machine) error {
+	if do.v1Alpha1Client == nil {
+		return nil
+	}
+
+	status := instanceStatus(machine)
+	currentMachine, err := util.GetMachineIfExists(do.v1Alpha1Client.Machines(machine.Namespace), machine.ObjectMeta.Name)
+	if err != nil {
+		return nil
+	}
+	if currentMachine == nil {
+		return fmt.Errorf("machine '%s' does not exist anymore, so status can't be updated", machine.ObjectMeta.Name)
+	}
+
+	m, err := do.setMachineInstanceStatus(currentMachine, status)
+	if err != nil {
+		return err
+	}
+
+	_, err = do.v1Alpha1Client.Machines(machine.Namespace).Update(m)
+	return err
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ports the InstanceStatus feature from upstream cluster-api controllers, so we can implement the machineUpdate method.

**Release note**:
```release-note
Implement InstanceStatus to allow status of the creation and updates to be saved as an annotation.
```