### PR TITLE
cloud/digitalocean: implement node upgrades

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1068,6 +1068,7 @@
     "golang.org/x/crypto/ssh",
     "golang.org/x/oauth2",
     "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements the `Update` method for nodes, which replaces the old node with a new node. First the old node is deleted, then the new node is created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #33.

**Release note**:

```release-note
Implement the update method for workers.
```