### PR TITLE
cloud/digitalocean: ignore already deleted droplets when deleting machine

### DIFF
--- a/cloud/digitalocean/actuators/machine/actuator.go
+++ b/cloud/digitalocean/actuators/machine/actuator.go
@@ -16,6 +16,7 @@ package machine
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -404,8 +405,12 @@ func (do *DOClient) instanceExists(machine *clusterv1.Machine) (*godo.Droplet, e
 		if err != nil {
 			return nil, err
 		}
-		droplet, _, err := do.godoClient.Droplets.Get(do.ctx, id)
+		droplet, resp, err := do.godoClient.Droplets.Get(do.ctx, id)
 		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
+				// Machine exists as an object, but Droplet is already deleted.
+				return nil, nil
+			}
 			return nil, err
 		}
 		if droplet != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds check to the `instanceExists` function to skip Machine if it has the ID annotation, but that Droplet doesn't exist anymore.

**Special notes for your reviewer**:

Related to #53

**Release note**:
```release-note
NONE
```