### PR TITLE
clusterctl: deploy Flannel CNI plugin

### DIFF
--- a/cloud/digitalocean/actuators/machine/actuator.go
+++ b/cloud/digitalocean/actuators/machine/actuator.go
@@ -387,7 +387,7 @@ func getKubeadm(params ActuatorParams) DOClientKubeadm {
 
 func (do *DOClient) getKubeadmToken() (string, error) {
 	tokenParams := kubeadm.TokenCreateParams{
-		Ttl: time.Duration(10) * time.Minute,
+		Ttl: time.Duration(30) * time.Minute,
 	}
 
 	token, err := do.kubeadm.TokenCreate(tokenParams)

--- a/clusterctl/examples/digitalocean/cluster.yaml.template
+++ b/clusterctl/examples/digitalocean/cluster.yaml.template
@@ -7,7 +7,7 @@ spec:
         services:
             cidrBlocks: ["10.96.0.0/12"]
         pods:
-            cidrBlocks: ["192.168.0.0/16"]
+            cidrBlocks: ["10.244.0.0/16"]
         serviceDomain: "cluster.local"
     providerConfig:
       value:

--- a/clusterctl/examples/digitalocean/machines.yaml.template
+++ b/clusterctl/examples/digitalocean/machines.yaml.template
@@ -36,7 +36,7 @@ items:
         size: "s-2vcpu-2gb"
         image: "ubuntu-18-04-x64"
         tags:
-        - "machine-1"
+        - "machine-2"
         sshPublicKeys:
         - "ssh-rsa AAAA"
         private_networking: true

--- a/clusterctl/examples/digitalocean/provider-components.yaml.template
+++ b/clusterctl/examples/digitalocean/provider-components.yaml.template
@@ -211,7 +211,6 @@ data:
         touch /etc/systemd/system/kubelet.service.d/20-kubenet.conf
         cat > /etc/systemd/system/kubelet.service.d/20-kubenet.conf <<EOF
         [Service]
-        Environment="KUBELET_NETWORK_ARGS="
         Environment="KUBELET_EXTRA_ARGS=--authentication-token-webhook=true --read-only-port=0 --cluster-domain=cluster.local --resolv-conf=/run/systemd/resolve/resolv.conf"
         EOF
         systemctl daemon-reload
@@ -231,14 +230,21 @@ data:
         - ${PUBLICIP}
         - ${PRIVATEIP}
         - ${HOSTNAME}
+        networking:
+          podSubnet: ${POD_CIDR}
         EOF
 
         kubeadm init --config /etc/kubernetes/kubeadm_config.yaml
 
         for tries in $(seq 1 60); do
+            # Annotate node.
             kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate --overwrite node ${HOSTNAME} machine=${MACHINE} && break
             sleep 1
         done
+
+        # Apply Flannel CNI
+        kubectl --kubeconfig /etc/kubernetes/kubelet.conf create -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+
         echo done.
         ) 2>&1 | tee /var/log/startup.log
     - machineParams:
@@ -337,7 +343,6 @@ data:
         touch /etc/systemd/system/kubelet.service.d/20-kubenet.conf
         cat > /etc/systemd/system/kubelet.service.d/20-kubenet.conf <<EOF
         [Service]
-        Environment="KUBELET_NETWORK_ARGS="
         Environment="KUBELET_EXTRA_ARGS=--read-only-port=0 --cluster-domain=cluster.local --resolv-conf=/run/systemd/resolve/resolv.conf"
         EOF
         systemctl daemon-reload


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the ProviderConfig bootstrap scripts to deploy the [Flannel](https://github.com/coreos/flannel#flannel) CNI plugin when deploying the cluster.

Also, the `kubeadm` token TTL is raised to prevent failures if worker takes longer time to provision.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #34.

**Release note**:
```release-note
Deploy Flannel CNI plugin with clusterctl.
```