### PR TITLE
clusterctl: use 1.11.3 by default

### DIFF
--- a/clusterctl/examples/digitalocean/machines.yaml.template
+++ b/clusterctl/examples/digitalocean/machines.yaml.template
@@ -21,8 +21,8 @@ items:
         # must be disabled for coreos instances.
         monitoring: true
     versions:
-      controlPlane: 1.9.4
-      kubelet: 1.9.4
+      controlPlane: 1.11.3
+      kubelet: 1.11.3
 - apiVersion: "cluster.k8s.io/v1alpha1"
   kind: Machine
   metadata:
@@ -45,4 +45,4 @@ items:
         # must be disabled for coreos instances.
         monitoring: true
     versions:
-      kubelet: 1.9.4
+      kubelet: 1.11.3

--- a/clusterctl/examples/digitalocean/provider-components.yaml.template
+++ b/clusterctl/examples/digitalocean/provider-components.yaml.template
@@ -132,8 +132,8 @@ data:
     - machineParams:
       - image: ubuntu-18-04-x64
         versions:
-          kubelet: 1.9.4
-          controlPlane: 1.9.4
+          kubelet: 1.11.3
+          controlPlane: 1.11.3
       userdata: |
         set -e
         set -x
@@ -243,14 +243,14 @@ data:
         done
 
         # Apply Flannel CNI
-        kubectl --kubeconfig /etc/kubernetes/kubelet.conf create -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+        kubectl --kubeconfig /etc/kubernetes/admin.conf create -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 
         echo done.
         ) 2>&1 | tee /var/log/startup.log
     - machineParams:
       - image: ubuntu-18-04-x64
         versions:
-          kubelet: 1.9.4
+          kubelet: 1.11.3
       userdata: |
         set -e
         set -x

--- a/vendor/sigs.k8s.io/cluster-api/clusterctl/clusterdeployer/clusterclient.go
+++ b/vendor/sigs.k8s.io/cluster-api/clusterctl/clusterdeployer/clusterclient.go
@@ -75,7 +75,7 @@ func (c *clusterClient) removeKubeconfigFile() error {
 }
 
 func (c *clusterClient) EnsureNamespace(namespaceName string) error {
-	clientset, err := clientcmd.NewCoreClientSetForKubeconfig(c.kubeconfigFile)
+	clientset, err := clientcmd.NewCoreClientSetForDefaultSearchPath(c.kubeconfigFile, clientcmd.NewConfigOverrides())
 	if err != nil {
 		return fmt.Errorf("error creating core clientset: %v", err)
 	}
@@ -96,7 +96,7 @@ func (c *clusterClient) DeleteNamespace(namespaceName string) error {
 	if namespaceName == apiv1.NamespaceDefault {
 		return nil
 	}
-	clientset, err := clientcmd.NewCoreClientSetForKubeconfig(c.kubeconfigFile)
+	clientset, err := clientcmd.NewCoreClientSetForDefaultSearchPath(c.kubeconfigFile, clientcmd.NewConfigOverrides())
 	if err != nil {
 		return fmt.Errorf("error creating core clientset: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates manifests to deploy Kubernetes 1.11.3 instead of 1.9.4 by default.

This is required, so we can deploy [`digitalocean-cloud-controller-manager`](https://github.com/digitalocean/digitalocean-cloud-controller-manager) and [`csi-digitalocean`](https://github.com/digitalocean/csi-digitalocean) as addons. If users want to use older Kubernetes versions, they can opt-out of using addons.

**Release note**:
```release-note
Deploy Kubernetes 1.11.3 instead of 1.9.4 by default.
```