### PR TITLE
clusterctl: deploy csi-digitalocean as addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To create your first cluster using `cluster-api-provider-digitalocean`, you need
 * `cluster.yaml` - defines Cluster properties, such as Pod and Services CIDR, Services Domain, etc.
 * `machines.yaml` - defines Machine properties, such as machine size, image, tags, SSH keys, enabled features, as well as what Kubernetes version will be used for each machine.
 * `provider-components.yaml` - contains deployment manifest for controllers, userdata used to bootstrap machines, a secret with SSH key for the `machine-controller` and a secret with DigitalOcean API Access Token.
-* [Optional] `addons.yaml` - used to deploy additional components once the cluster is bootstrapped, such as an ingress controller.
+* [Optional] `addons.yaml` - used to deploy additional components once the cluster is bootstrapped, such as [DigitalOcean CSI plugin](https://github.com/digitalocean/csi-digitalocean).
 
 The manifests can be generated automatically by using the [`generate-yaml.sh`](./clusterctl/examples/digitalocean/generate-yaml.sh) script, located in the `clusterctl/examples/digitalocean` directory:
 ```bash
@@ -71,7 +71,8 @@ Once you have manifests generated, you can create a cluster using the following 
     --vm-driver kvm2 \
     -c ./clusterctl/examples/digitalocean/out/cluster.yaml \
     -m ./clusterctl/examples/digitalocean/out/machines.yaml \
-    -p ./clusterctl/examples/digitalocean/out/provider-components.yaml
+    -p ./clusterctl/examples/digitalocean/out/provider-components.yaml \
+    -a ./clusterctl/examples/digitalocean/out/addons.yaml
 ```
 
 More details about the `create cluster` command can be found by invoking help:
@@ -84,6 +85,7 @@ The `clusterctl`'s workflow is:
 * Deploy the `cluster-api-controller`, `digitalocean-machine-controller` and `digitalocean-cluster-controller`, on the bootstrap cluster,
 * Create a Master, download `kubeconfig` file, and deploy controllers on the Master,
 * Create other specified machines (nodes),
+* Deploy addon components (currently only `csi-digitalocean`),
 * Remove the local Minikube cluster.
 
 ### Interacting With Your New Cluster

--- a/clusterctl/examples/digitalocean/addons.yaml.template
+++ b/clusterctl/examples/digitalocean/addons.yaml.template
@@ -1,0 +1,243 @@
+# DigitalOcean API Access Token Secret
+apiVersion: v1
+kind: Secret
+metadata:
+  name: digitalocean
+  namespace: kube-system
+type: Opaque
+stringData:
+  token: $DIGITALOCEAN_ACCESS_TOKEN
+---
+####################
+#                  #
+# csi-digitalocean #
+#                  #
+####################
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: do-block-storage
+  namespace: kube-system
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: com.digitalocean.csi.dobs
+---
+# csi-digitalocean: controller-plugin
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: csi-do-controller
+  namespace: kube-system
+spec:
+  serviceName: "csi-do"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: csi-do-controller
+        role: csi-do
+    spec:
+      serviceAccount: csi-do-controller-sa
+      containers:
+      - name: csi-provisioner
+        image: quay.io/k8scsi/csi-provisioner:v0.3.0
+        args:
+        - "--provisioner=com.digitalocean.csi.dobs"
+        - "--csi-address=$(ADDRESS)"
+        - "--v=5"
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        imagePullPolicy: "Always"
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-attacher
+        image: quay.io/k8scsi/csi-attacher:v0.3.0
+        args:
+        - "--v=5"
+        - "--csi-address=$(ADDRESS)"
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        imagePullPolicy: "Always"
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-do-plugin
+        image: digitalocean/do-csi-plugin:v0.2.0
+        args :
+        - "--endpoint=$(CSI_ENDPOINT)"
+        - "--token=$(DIGITALOCEAN_ACCESS_TOKEN)"
+        - "--url=$(DIGITALOCEAN_API_URL)"
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: DIGITALOCEAN_API_URL
+          value: https://api.digitalocean.com/
+        - name: DIGITALOCEAN_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: digitalocean
+              key: token
+        imagePullPolicy: "Always"
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+      - name: socket-dir
+        emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-do-controller-sa
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-do-controller-provisioner-binding
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: csi-do-controller-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:csi-external-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-do-controller-attacher-binding
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: csi-do-controller-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:csi-external-attacher
+  apiGroup: rbac.authorization.k8s.io
+---
+# csi-digitalocean: node-plugin
+kind: DaemonSet
+apiVersion: apps/v1beta2
+metadata:
+  name: csi-do-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: csi-do-node
+  template:
+    metadata:
+      labels:
+        app: csi-do-node
+        role: csi-do
+    spec:
+      serviceAccount: csi-do-node-sa
+      hostNetwork: true
+      containers:
+      - name: driver-registrar
+        image: quay.io/k8scsi/driver-registrar:v0.3.0
+        args:
+        - "--v=5"
+        - "--csi-address=$(ADDRESS)"
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi/
+          # TODO(arslan): the registrar is not implemented yet
+          # - name: registrar-socket-dir
+          #   mountPath: /var/lib/csi/sockets/
+      - name: csi-do-plugin
+        image: digitalocean/do-csi-plugin:v0.2.0
+        args :
+        - "--endpoint=$(CSI_ENDPOINT)"
+        - "--token=$(DIGITALOCEAN_ACCESS_TOKEN)"
+        - "--url=$(DIGITALOCEAN_API_URL)"
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        - name: DIGITALOCEAN_API_URL
+          value: https://api.digitalocean.com/
+        - name: DIGITALOCEAN_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: digitalocean
+              key: token
+        imagePullPolicy: "Always"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+        - name: pods-mount-dir
+          mountPath: /var/lib/kubelet
+          # needed so that any mounts setup inside this container are
+          # propagated back to the host machine.
+          mountPropagation: "Bidirectional"
+        - name: device-dir
+          mountPath: /dev
+      volumes:
+      # TODO(arslan): the registar is not implemented yet
+      #- name: registrar-socket-dir
+      #  hostPath:
+      #    path: /var/lib/kubelet/device-plugins/
+      #    type: DirectoryOrCreate
+      - name: plugin-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/com.digitalocean.csi.dobs
+          type: DirectoryOrCreate
+      - name: pods-mount-dir
+        hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+      - name: device-dir
+        hostPath:
+          path: /dev
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-do-node-sa
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-do-driver-registrar-binding
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: csi-do-node-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-do-driver-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-do-driver-registrar-role
+  namespace: kube-system
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "update"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["list", "watch", "create", "update", "patch"]

--- a/clusterctl/examples/digitalocean/generate-yaml.sh
+++ b/clusterctl/examples/digitalocean/generate-yaml.sh
@@ -10,6 +10,8 @@ MACHINES_TEMPLATE_FILE=machines.yaml.template
 MACHINES_GENERATED_FILE=${OUTPUT_DIR}/machines.yaml
 CLUSTER_TEMPLATE_FILE=cluster.yaml.template
 CLUSTER_GENERATED_FILE=${OUTPUT_DIR}/cluster.yaml
+ADDONS_TEMPLATE_FILE=addons.yaml.template
+ADDONS_GENERATED_FILE=${OUTPUT_DIR}/addons.yaml
 
 REGION=${REGION:-fra1}
 CLUSTER_NAME=${CLUSTER_NAME:-test-1}
@@ -61,6 +63,11 @@ if [ $OVERWRITE -ne 1 ] && [ -f $CLUSTER_GENERATED_FILE ]; then
   exit 1
 fi
 
+if [ $OVERWRITE -ne 1 ] && [ -f $ADDONS_GENERATED_FILE ]; then
+  echo "File $ADDONS_GENERATED_FILE already exists. Delete it manually before running this script."
+  exit 1
+fi
+
 if [ $OVERWRITE -ne 1 ] && [ -f $SSH_KEY_GENERATED_FILE ]; then
   echo "File $SSH_KEY_GENERATED_FILE already exists. Delete it manually before running this script."
   exit 1
@@ -96,3 +103,7 @@ cat $CLUSTER_TEMPLATE_FILE \
   > $CLUSTER_GENERATED_FILE
 echo "Done generating $CLUSTER_GENERATED_FILE"
 
+cat $ADDONS_TEMPLATE_FILE \
+    | sed -e "s/\$DIGITALOCEAN_ACCESS_TOKEN/$DIGITALOCEAN_ACCESS_TOKEN/" \
+  > $ADDONS_GENERATED_FILE
+echo "Done generating $ADDONS_GENERATED_FILE"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the `addons.yaml` manifest used to deploy additional components while bootstrapping the cluster. Currently, it deploys [DigitalOcean CSI plugin](https://github.com/digitalocean/csi-digitalocean), which allows us to use [DigitalOcean Block Storage](https://www.digitalocean.com/products/storage/) as PersistentVolumeClaims.

With CSI plugin in-place, new PVC can be created such as:

```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: csi-pvc
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  storageClassName: do-block-storage
```

Then, you can mount it to pods such as any other volume and use it like that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #38.

**Documentation**:

The main README.md is updated to include more details me about the `addons.yaml` manifest.

**Release note**:
```release-note
clusterctl: Deploy DigitalOcean CSI plugin as addon when bootstrapping cluster.
```