### PR TITLE
 clusterctl: deploy do-ccm as addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To create your first cluster using `cluster-api-provider-digitalocean`, you need
 * `cluster.yaml` - defines Cluster properties, such as Pod and Services CIDR, Services Domain, etc.
 * `machines.yaml` - defines Machine properties, such as machine size, image, tags, SSH keys, enabled features, as well as what Kubernetes version will be used for each machine.
 * `provider-components.yaml` - contains deployment manifest for controllers, userdata used to bootstrap machines, a secret with SSH key for the `machine-controller` and a secret with DigitalOcean API Access Token.
-* [Optional] `addons.yaml` - used to deploy additional components once the cluster is bootstrapped, such as [DigitalOcean CSI plugin](https://github.com/digitalocean/csi-digitalocean).
+* [Optional] `addons.yaml` - used to deploy additional components once the cluster is bootstrapped, such as [DigitalOcean Cloud Controller Manager](https://github.com/digitalocean/digitalocean-cloud-controller-manager) and [DigitalOcean CSI plugin](https://github.com/digitalocean/csi-digitalocean).
 
 The manifests can be generated automatically by using the [`generate-yaml.sh`](./clusterctl/examples/digitalocean/generate-yaml.sh) script, located in the `clusterctl/examples/digitalocean` directory:
 ```bash
@@ -85,7 +85,7 @@ The `clusterctl`'s workflow is:
 * Deploy the `cluster-api-controller`, `digitalocean-machine-controller` and `digitalocean-cluster-controller`, on the bootstrap cluster,
 * Create a Master, download `kubeconfig` file, and deploy controllers on the Master,
 * Create other specified machines (nodes),
-* Deploy addon components (currently only `csi-digitalocean`),
+* Deploy addon components ([`digitalocean-cloud-controller-manager`](https://github.com/digitalocean/digitalocean-cloud-controller-manager) and [`csi-digitalocean`](https://github.com/digitalocean/csi-digitalocean)),
 * Remove the local Minikube cluster.
 
 ### Interacting With Your New Cluster

--- a/clusterctl/examples/digitalocean/addons.yaml.template
+++ b/clusterctl/examples/digitalocean/addons.yaml.template
@@ -8,6 +8,160 @@ type: Opaque
 stringData:
   token: $DIGITALOCEAN_ACCESS_TOKEN
 ---
+#########################################
+#                                       #
+# digitalocean-cloud-controller-manager #
+#                                       #
+#########################################
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: digitalocean-cloud-controller-manager
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: digitalocean-cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        k8s-app: digitalocean-cloud-controller-manager
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      serviceAccountName: cloud-controller-manager
+      dnsPolicy: Default
+      hostNetwork: true
+      tolerations:
+        - key: "node.cloudprovider.kubernetes.io/uninitialized"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 300
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 300
+      containers:
+      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.7
+        name: digitalocean-cloud-controller-manager
+        command:
+          - "/bin/digitalocean-cloud-controller-manager"
+          - "--cloud-provider=digitalocean"
+          - "--leader-elect=true"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        env:
+          - name: KUBERNETES_SERVICE_HOST
+            value: "127.0.0.1"
+          - name: KUBERNETES_SERVICE_PORT
+            value: "443"
+          - name: DO_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: digitalocean
+                key: token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:cloud-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
 ####################
 #                  #
 # csi-digitalocean #

--- a/clusterctl/examples/digitalocean/provider-components.yaml.template
+++ b/clusterctl/examples/digitalocean/provider-components.yaml.template
@@ -211,7 +211,7 @@ data:
         touch /etc/systemd/system/kubelet.service.d/20-kubenet.conf
         cat > /etc/systemd/system/kubelet.service.d/20-kubenet.conf <<EOF
         [Service]
-        Environment="KUBELET_EXTRA_ARGS=--authentication-token-webhook=true --read-only-port=0 --cluster-domain=cluster.local --resolv-conf=/run/systemd/resolve/resolv.conf"
+        Environment="KUBELET_EXTRA_ARGS=--allow-privileged=true --cloud-provider=external --authentication-token-webhook=true --read-only-port=0 --cluster-domain=cluster.local --resolv-conf=/run/systemd/resolve/resolv.conf"
         EOF
         systemctl daemon-reload
         systemctl restart kubelet.service
@@ -230,6 +230,7 @@ data:
         - ${PUBLICIP}
         - ${PRIVATEIP}
         - ${HOSTNAME}
+        - 127.0.0.1
         networking:
           podSubnet: ${POD_CIDR}
         EOF
@@ -343,7 +344,7 @@ data:
         touch /etc/systemd/system/kubelet.service.d/20-kubenet.conf
         cat > /etc/systemd/system/kubelet.service.d/20-kubenet.conf <<EOF
         [Service]
-        Environment="KUBELET_EXTRA_ARGS=--read-only-port=0 --cluster-domain=cluster.local --resolv-conf=/run/systemd/resolve/resolv.conf"
+        Environment="KUBELET_EXTRA_ARGS=--allow-privileged=true --read-only-port=0 --cluster-domain=cluster.local --resolv-conf=/run/systemd/resolve/resolv.conf"
         EOF
         systemctl daemon-reload
         systemctl restart kubelet.service


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates addons manifest to deploy [DigitalOcean Cloud Controller Manager](https://github.com/digitalocean/digitalocean-cloud-controller-manager) when provisioning clusters.

The two key features of [DigitalOcean Cloud Controller Manager](https://github.com/digitalocean/digitalocean-cloud-controller-manager) are:

* node controller: annotates and controls nodes. When node is removed from the cloud (e.g. Machine object is removed), the node will be removed from Kubernetes as well
* loadbalacner controller: service type LoadBalancer based on [DigitalOcean Load Balancers](https://www.digitalocean.com/products/load-balancer/) is supported

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #37.

**Documentation**:

Updated the main `README.md` to mention CCM is deployed as addon.

**Release note**:
```release-note
clusterctl: Deploy DigitalOcean Cloud Controller Manager when provisioning cluster.
```