### PR TITLE
clusterctl: do not deploy cluster-controller

### DIFF
--- a/clusterctl/examples/digitalocean/provider-components.yaml.template
+++ b/clusterctl/examples/digitalocean/provider-components.yaml.template
@@ -44,30 +44,6 @@ spec:
           limits:
             cpu: 100m
             memory: 30Mi
-      - name: digitalocean-cluster-controller
-        image: quay.io/kubermatic/digitalocean-cluster-controller:0.0.1
-        volumeMounts:
-          - name: config
-            mountPath: /etc/kubernetes
-          - name: certs
-            mountPath: /etc/ssl/certs
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        command:
-        - "./cluster-controller"
-        args:
-        - --kubeconfig=/etc/kubernetes/admin.conf
-        - --leader-elect
-        resources:
-          requests:
-            cpu: 200m
-            memory: 200Mi
-          limits:
-            cpu: 400m
-            memory: 500Mi
       - name: digitalocean-machine-controller
         image: quay.io/kubermatic/digitalocean-machine-controller:0.0.1
         volumeMounts:


### PR DESCRIPTION
**What this PR does / why we need it**:

We have decided not to implement `cluster-controller` and `cluster-actuator`, as we don't have resources to manage with it on DigitalOcean.

In future if decided, it could be extend to mange firewalls, or something similar, but for now, no need to deploy it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #31.

**Release note**:
```release-note
NONE
```