### PR TITLE
clusterctl, docs: use hostNetwork for clusterapi-controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Checkout the Features portion of the README for details about the project status
 In order to create a cluster using `clusterctl`, you need the following tools installed on your local machine:
 
 * `kubectl`, which can be done by following [this tutorial](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-* [`minikube`](https://kubernetes.io/docs/tasks/tools/install-minikube/) and the appropriate [`minikube` driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md). We recommend `kvm2` for Linux and `virtualbox` for macOS
+* [`minikube`](https://kubernetes.io/docs/tasks/tools/install-minikube/) and the appropriate [`minikube` driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md). Minikube version < 0.28 is recommend due to an upstream bug (see [#79](https://github.com/kubermatic/cluster-api-provider-digitalocean/issues/78) for more details) We recommend `kvm2` driver for Linux and `virtualbox` for macOS.
 * [DigitalOcean API Access Token generated](https://www.digitalocean.com/docs/api/create-personal-access-token/) and set as the `DIGITALOCEAN_ACCESS_TOKEN` environment variable,
 * Go toolchain [installed and configured](https://golang.org/doc/install), needed in order to compile the `clusterctl` binary,
 * `cluster-api-provider-digitalocean` repository cloned:

--- a/clusterctl/examples/digitalocean/provider-components.yaml.template
+++ b/clusterctl/examples/digitalocean/provider-components.yaml.template
@@ -12,6 +12,7 @@ spec:
       labels:
         api: clusterapi
     spec:
+      hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:


### PR DESCRIPTION
**What this PR does / why we need it**:

There is an upstream bug which prevents Minikube > 0.28 from working correctly with clusterctl.

@alvaroaleman mentioned that setting `hostNetwork: true` for clusterapi-controllers deployment seems to fix the issue (#78).

This fix is not an elegant solution but should help until upstream issue is not fixed.

Relevant upstream issue: https://github.com/kubernetes-sigs/cluster-api/issues/475

Documentation is updated to recommend Minikube < 0.28.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Partially Addresses #73

**Release note**:
```release-note
NONE
```