### PR TITLE
fail early if DIGITALOCEAN_ACCESS_TOKEN is not set

### DIFF
--- a/cloud/digitalocean/actuators/machine/auth.go
+++ b/cloud/digitalocean/actuators/machine/auth.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"github.com/digitalocean/godo"
+	"github.com/golang/glog"
+
 	"golang.org/x/oauth2"
 )
 
@@ -23,9 +25,15 @@ func (t *tokenSource) Token() (*oauth2.Token, error) {
 
 // getGodoClient creates new godo client used to interact with the DigitalOcean API.
 func getGodoClient() *godo.Client {
-	token := &tokenSource{
-		AccessToken: os.Getenv("DIGITALOCEAN_ACCESS_TOKEN"),
+	doToken := os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
+	if doToken == "" {
+		glog.Fatalf("env var DIGITALOCEAN_ACCESS_TOKEN is required")
 	}
+
+	token := &tokenSource{
+		AccessToken: doToken,
+	}
+
 	oc := oauth2.NewClient(context.Background(), token)
 	return godo.NewClient(oc)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fail early if DIGITALOCEAN_ACCESS_TOKEN is not set. This should make debugging config issues much easier in case a user forgets to set it. 

```release-note
fail early if DIGITALOCEAN_ACCESS_TOKEN is not set
```

cc @xmudrii 