### PR TITLE
Use new push Make target in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,7 @@ jobs:
         set -e
         export GIT_TAG=$CIRCLE_TAG
         docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}" quay.io
-        make images-nodep
-        make push-nodep
+        make push
 
   e2e:
     machine: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes CirleCI to use new instead of old Make target for publishing images to Quay.

**Release note**:

```release-note
NONE
```