### PR TITLE
Update Makefiles to 0.3.0 and 0.3.0-dev

### DIFF
--- a/cmd/cluster-controller/Makefile
+++ b/cmd/cluster-controller/Makefile
@@ -17,8 +17,8 @@
 QUAY_BUCKET = kubermatic
 PREFIX = quay.io/$(QUAY_BUCKET)
 NAME = digitalocean-cluster-controller
-TAG = 0.2.0
-DEV_TAG = 0.2.0-dev
+TAG = 0.3.0
+DEV_TAG = 0.3.0-dev
 
 image: ## Build image
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../..

--- a/cmd/machine-controller/Makefile
+++ b/cmd/machine-controller/Makefile
@@ -17,8 +17,8 @@
 QUAY_BUCKET = kubermatic
 PREFIX = quay.io/$(QUAY_BUCKET)
 NAME = digitalocean-machine-controller
-TAG = 0.2.0
-DEV_TAG = 0.2.0-dev
+TAG = 0.3.0
+DEV_TAG = 0.3.0-dev
 
 image: ## Build image
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../..


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates Makefile to push images to `0.3.0` and `0.3.0-dev` tags.

**Release note**:

```release-note
NONE
```