### PR TITLE
Establish OWNERS and OWNERS_ALIASES files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+#  - sig-cluster-lifecycle-leads
+  - cluster-api-admins
+  - cluster-api-maintainers
+  - cluster-api-do-maintainers
+
+reviewers:
+  - cluster-api-maintainers
+  - cluster-api-do-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
+aliases:
+#  sig-cluster-lifecycle-leads:
+  cluster-api-admins:
+    - kris-nova
+  cluster-api-maintainers:
+    - kris-nova
+  cluster-api-do-maintainers:
+    - andrewsykim
+    - alvaroaleman
+    - nikhita
+    - xmudrii


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR establish initial OWNERS file required for upstreaming Cluster-API provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Partially addresses #105 

**Special notes for your reviewer**:

We need lazy vote on this PR by everyone mentioned in OWNERS.

@kris-nova @andrewsykim @alvaroaleman @nikhita 

**Release note**:

```release-note
NONE
```