### PR TITLE
Add SECURITY_CONTACTS

### DIFF
--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,0 +1,16 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Team to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+luxas
+roberthbailey
+timothysc
+xmudrii


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the `SECURITY_CONTACTS` file since it is a template file needed for all upstream repos as per https://github.com/kubernetes/kubernetes-template-project.

Adds the same folks as those mentioned in OWNERS.

**Which issue(s) this PR fixes**: For https://github.com/kubermatic/cluster-api-provider-digitalocean/issues/105

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

cc @andrewsykim @alvaroaleman @kris-nova @xmudrii 