### PR TITLE
Update OWNERS to match cluster-api OWNERS state

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,10 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-#  - sig-cluster-lifecycle-leads
+  - sig-cluster-lifecycle-leads
+  - sig-cloud-provider-leads
   - cluster-api-admins
-  - cluster-api-maintainers
   - cluster-api-do-maintainers
 
 reviewers:
-  - cluster-api-maintainers
   - cluster-api-do-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,11 +1,18 @@
 # See the OWNERS docs: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
 
 aliases:
-#  sig-cluster-lifecycle-leads:
+  sig-cluster-lifecycle-leads:
+    - luxas
+    - roberthbailey
+    - timothysc
   cluster-api-admins:
+    - justinsb
     - kris-nova
-  cluster-api-maintainers:
-    - kris-nova
+    - krousey
+    - luxas
+    - roberthbailey
+  sig-cloud-provider-leads:
+    - andrewsykim
   cluster-api-do-maintainers:
     - andrewsykim
     - alvaroaleman


### PR DESCRIPTION
**What this PR does / why we need it**:

As per discussion with @roberthbailey, this PR updates the ownership files to match the state of cluster-api ownership.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Addresses part of #105 

**Release note**:
```release-note
NONE
```

/cc @roberthbailey @timothysc